### PR TITLE
Throw an Exception if a request fails

### DIFF
--- a/SimpleChurchAPI.php
+++ b/SimpleChurchAPI.php
@@ -161,7 +161,24 @@ class SimpleChurchAPI
 		$context = stream_context_create(array('http' => $opts));
 		$result = file_get_contents($url, FALSE, $context);
 
+		if (!$result) {
+			$this->throwResponseException($http_response_header);
+		}
+
 		return json_decode($result);
+	}
+
+	private function throwResponseException($headers)
+	{
+		if (!$headers) {
+			return false;
+		}
+
+		$status = $headers[0];
+
+		list( , $statusCode, $statusDescription) = explode(' ', $status, 3);
+
+		throw new Exception($statusDescription, $statusCode);
 	}
 }
 	


### PR DESCRIPTION
Hey @simplechurchcrm,

Something we've struggled with is determining _why_ an API request fails. For example, if the session ID is bad, this is thrown:

```php
object(Exception)#23 (7) {
  ["message":protected]=>
  string(0) ""
  ["string":"Exception":private]=>
  string(0) ""
  ["code":protected]=>
  int(0)
  ...
```

There's no `message` or `code` because no `error` field is returned in the JSON response (nothing is returned).

This pull request helps by throwing the following instead:

```php
object(Exception)#23 (7) {
  ["message":protected]=>
  string(12) "Unauthorized"
  ["string":"Exception":private]=>
  string(0) ""
  ["code":protected]=>
  int(401)
  ...
```

The code is quick and dirty because I have a question before continuing. When is an `error` field returned? What does it look like?

Thanks!