### PR TITLE
Use actual response error/status with exceptions

### DIFF
--- a/SimpleChurchAPI.php
+++ b/SimpleChurchAPI.php
@@ -25,42 +25,23 @@ class SimpleChurchAPI
 	public function login($username, $password)
 	{
 		$ret = $this->doPost('user/login', array(
-		   'username' => $username,
-		   'password' => $password
+			'username' => $username,
+			'password' => $password
 		));
-		
-		if (!$ret->success)
-		{
-			throw new Exception('Invalid Username or Password');
-		}
-		else
-		{
-			$this->setSessionId($ret->data->session_id);
-		}
-		
-		return $ret->data;
+
+		$this->setSessionId($ret->session_id);
+
+		return $ret;
 	}
 	
 	public function createPerson($params)
 	{
-		$ret = $this->doPost('people', $params);
-		
-		if (!$ret->success)
-		{
-			throw new Exception($ret->error);
-		}
-		
-		return $ret->data;
+		return $this->doPost('people', $params);
 	}
 	
 	public function addPersonToGroup($uid, $gid)
 	{
-		$ret = $this->doPost('people/'.$uid.'/add_to_group', array('gid' => $gid));
-		
-		if (!$ret->success)
-		{
-			throw new Exception($ret->error);
-		}
+		return $this->doPost('people/'.$uid.'/add_to_group', array('gid' => $gid));
 	}
 	
 	public function assignInteraction($params)
@@ -79,14 +60,7 @@ class SimpleChurchAPI
 	
 	private function createInteraction($params)
 	{
-		$ret = $this->doPost('interactions', $params);
-		
-		if (!$ret->success)
-		{
-			throw new Exception($ret->error);
-		}
-		
-		return $ret->data;
+		return $this->doPost('interactions', $params);
 	}
 	
 	public function getSessionId()
@@ -103,26 +77,12 @@ class SimpleChurchAPI
 
 	public function getCalendarEvents($params)
 	{
-		$ret = $this->doGet('calendar/events', $params);
-
-		if (!$ret->success)
-		{
-			throw new Exception($ret->error);
-		}
-
-		return $ret->data;
+		return $this->doGet('calendar/events', $params);
 	}
 
 	public function getCalendarViews()
 	{
-		$ret = $this->doGet('calendar/views');
-
-		if (!$ret->success)
-		{
-			throw new Exception($ret->error);
-		}
-
-		return $ret->data;
+		return $this->doGet('calendar/views');
 	}
 
 	private function buildRequestUrl($path, $params = array())
@@ -139,46 +99,61 @@ class SimpleChurchAPI
 
 	private function doGet($path, $params = array())
 	{
-		return $this->doRequest($this->buildRequestUrl($path, $params), array(
-			'method' => 'GET',
-			'header' => array('Content-type: application/json')
-		));
+		$headers = array('Content-type: application/json');
+
+		return $this->doRequest('GET', $this->buildRequestUrl($path, $params), $headers);
 	}
 
 	private function doPost($path, $params)
 	{
-		return $this->doRequest($this->buildRequestUrl($path), array(
-			'method'  => 'POST',
-			'header'  => array('Content-type: application/x-www-form-urlencoded'),
-			'content' => http_build_query($params)
-		));
+		$headers = array('Content-type: application/x-www-form-urlencoded');
+
+		return $this->doRequest('POST', $this->buildRequestUrl($path), $headers, $params);
 	}
 
-	private function doRequest($url, $opts)
+	private function doRequest($method, $url, $headers = array(), $params = array())
 	{
-		$opts['header'][] = 'X-SessionId: '.$this->getSessionId();
+		$headers[] = 'X-SessionId: '.$this->getSessionId();
 
-		$context = stream_context_create(array('http' => $opts));
-		$result = file_get_contents($url, FALSE, $context);
+		$request = curl_init();
 
-		if (!$result) {
-			$this->throwResponseException($http_response_header);
+		curl_setopt($request, CURLOPT_CUSTOMREQUEST, $method);
+		curl_setopt($request, CURLOPT_URL, $url);
+		curl_setopt($request, CURLOPT_HTTPHEADER, $headers);
+		curl_setopt($request, CURLOPT_RETURNTRANSFER, true);
+
+		if ($params)
+		{
+			curl_setopt($request, CURLOPT_POSTFIELDS, http_build_query($params));
 		}
 
-		return json_decode($result);
+		$response = curl_exec($request);
+		$response = json_decode($response);
+
+		$statusCode = curl_getinfo($request, CURLINFO_HTTP_CODE);
+
+		curl_close($request);
+
+		$this->throwExceptionIfError($response, $statusCode);
+
+		return $response->data;
 	}
 
-	private function throwResponseException($headers)
+	private function throwExceptionIfError($response, $statusCode = null)
 	{
-		if (!$headers) {
+		if ($response && $response->success)
+		{
 			return false;
 		}
 
-		$status = $headers[0];
-
-		list( , $statusCode, $statusDescription) = explode(' ', $status, 3);
-
-		throw new Exception($statusDescription, $statusCode);
+		if ($response)
+		{
+			throw new Exception($response->error, $response->statusCode);
+		}
+		else
+		{
+			throw new Exception('No response', $statusCode);
+		}
 	}
 }
 	


### PR DESCRIPTION
Since `file_get_contents` doesn't return the response when there's an
error, it had to be replaced with cURL.

Additionally, since request exceptions are now thrown from `doRequest`,
it was possible to remove similar code in all dependent methods.